### PR TITLE
[backend] Added api rate limiter

### DIFF
--- a/backend/controllers/auth.controller.ts
+++ b/backend/controllers/auth.controller.ts
@@ -98,6 +98,12 @@ export const logout = async (req: Request, res: Response) => {
   return res.status(200).json({ message: "logged out successfully" });
 };
 
+/**
+ * This function retrieves an access token using a refresh token and returns it in a JSON response.
+ * @returns a JSON response with an access token if the refresh token provided in the request payload
+ * is valid and exists in the database. If the token is not found or invalid, it returns a custom error
+ * message with a 400 status code.
+ */
 export const getAccessToken = async (req: Request, res: Response) => {
   const { refreshToken } = req.body;
   // check if token is in request payload
@@ -108,6 +114,7 @@ export const getAccessToken = async (req: Request, res: Response) => {
   // verify if token is valid
   const payload = await useToken(refreshToken, false);
   if (!payload) return res.sendCustomErrorMessage("Invalid token", 400);
+  // generate new access token and return in response
   const accessToken = await generateAccessToken(user as User);
   return res.status(200).json({ accessToken });
 };

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -48,10 +48,17 @@ mongoose.connect(databaseURI).then(
 import routes from "./routes";
 import baseMiddleware from "@app/middleware/base.middleware";
 import authMiddleware from "@app/middleware/auth.middleware";
+import rateLimiter from "@app/middleware/rateLimiter.middleware";
 import { HOST, PORT } from "@app/constants";
 
 const app = express();
-app.use("/api/auth", express.json(), baseMiddleware, require("@routes/auth"));
+app.use(
+  "/api/auth",
+  express.json(),
+  rateLimiter, // limit each IP to 2 requests per 5 seconds
+  baseMiddleware,
+  require("@routes/auth")
+);
 app.use("/api", express.json(), baseMiddleware, authMiddleware, routes);
 app.listen(PORT, () =>
   console.log(`%cServer started successfully ${HOST}:${PORT}`, "color: green")

--- a/backend/middleware/rateLimiter.middleware.ts
+++ b/backend/middleware/rateLimiter.middleware.ts
@@ -1,0 +1,6 @@
+import rateLimit from "express-rate-limit";
+const rateLimiter = rateLimit({
+  windowMs: 5 * 1000, // 5 seconds
+  max: 2, // limit each IP to 2 requests per windowMs
+});
+export default rateLimiter;

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-handlebars": "^7.0.2",
+    "express-rate-limit": "^6.7.0",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^6.7.5",
     "nodemailer": "^6.9.1",

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -2642,6 +2642,7 @@ __metadata:
     dotenv: "npm:^16.0.3"
     express: "npm:^4.18.2"
     express-handlebars: "npm:^7.0.2"
+    express-rate-limit: "npm:^6.7.0"
     jest: "npm:^29.5.0"
     jsonwebtoken: "npm:^9.0.0"
     mongoose: "npm:^6.7.5"
@@ -2958,6 +2959,15 @@ __metadata:
     graceful-fs: "npm:^4.2.10"
     handlebars: "npm:^4.7.7"
   checksum: 7409b71cc83528731a3bdf6c84af2eacbdf935f2b6fe10e298795e7583cea3ca32742813e2fb2b9b178ed3227c1f99beece7aea115c6e24054af4c4719525692
+  languageName: node
+  linkType: hard
+
+"express-rate-limit@npm:^6.7.0":
+  version: 6.7.0
+  resolution: "express-rate-limit@npm:6.7.0"
+  peerDependencies:
+    express: ^4 || ^5
+  checksum: 5bee337c88cb81b5ac777664e854254b0885d51d1f88b115b39dcac8b81b0292a453f0865927f9e6ca8dba07246674f188d5e8095a13d1c32f487aae7ddc9bc2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Added rate limiter using "express-rate-limit", which will limit API requests for the same IP address. Currently set a limit for 2 requests per 5 seconds.