### PR TITLE
[frontend] Now .env variables can be access in webpack

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "babel-loader": "^9.1.2",
+    "dotenv": "^16.1.4",
     "html-webpack-plugin": "^5.5.1",
     "postcss-loader": "^7.3.0",
     "sass": "^1.62.1",

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,3 +1,4 @@
+require('dotenv').config(); // Load environment variables synchronously (.env)
 const path = require('path');
 const HTMLWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
@@ -13,6 +14,7 @@ module.exports = (env) => {
   const IS_DEV_MODE = !!env.development;
   const environment = IS_PRODUCTION ? 'production' : 'development';
   const staticPrefix = path.join(__dirname, '.');
+  const BACKEND_API = process.env.BACKEND_API || "http://localhost:3001";
 
   console.log(`
 =============================================
@@ -20,7 +22,7 @@ Starting frontend (${environment}), please wait...`);
 
   if (!IS_PRODUCTION) {
     console.log("All environment variables:");
-    console.log(env);
+    console.log({ ...env, BACKEND_API });
   }
 
   return {
@@ -131,7 +133,7 @@ Starting frontend (${environment}), please wait...`);
       // Without this page will not load on reload for a subpath url
       historyApiFallback: true,
       proxy: {
-        '/api': 'http://localhost:3001',
+        '/api': BACKEND_API,
         changeOrigin: true,
       },
     },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3075,6 +3075,7 @@ __metadata:
     axios: "npm:^1.4.0"
     babel-loader: "npm:^9.1.2"
     css-loader: "npm:^6.7.4"
+    dotenv: "npm:^16.1.4"
     html-webpack-plugin: "npm:^5.5.1"
     mini-css-extract-plugin: "npm:^2.7.6"
     postcss-loader: "npm:^7.3.0"
@@ -3330,6 +3331,13 @@ __metadata:
     no-case: "npm:^3.0.4"
     tslib: "npm:^2.0.3"
   checksum: 951f9f8423106c57ba5f078e5d81cf810a94d20b16e50ea26369942b634bb30789677756a267320907b250b8c0432b598da719ade592c727968bb1f8cfefa8c6
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.1.4":
+  version: 16.1.4
+  resolution: "dotenv@npm:16.1.4"
+  checksum: c8eb9665ee670f2d3aa36b6f3dc43a9108a02da9efaa86cb9890d6873cbc025b047e30ce23f852195be8e4a2601b7684c23173d937d754443c4fbc957e1da512
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Added dotenv package to access .env variables
- backend API address will used from "BACKEND_API" env variable (default will be "http://localhost:3001" if not set in .env)