### PR TITLE
Fixed - Prevent vercel preview/auto deployment for a specific branch ("gh-pages") #76

### DIFF
--- a/.github/workflows/backend-test-coverage.yml
+++ b/.github/workflows/backend-test-coverage.yml
@@ -31,6 +31,15 @@ jobs:
             exit 1
           fi
 
+      # We need to create a empty "frontend" folder to silence below vercel build error and allow "Ignored Build Step" to run
+      # which will stop vercel build for "gh-pages"
+      # Error: The specified Root Directory "frontend" does not exist. Please update your Project Settings.
+      - name: Creating empty frontend folder
+        run: |
+          mkdir -p ./backend/coverage/frontend
+          touch ./backend/coverage/frontend/empty
+          tree -I node_modules
+
       - name: Move coverage report to gh-pages branch
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
"Ignored Build Step" was not working because of the below build error

"Error: The specified Root Directory "frontend" does not exist. Please update your Project Settings. Learn More: https://vercel.com/docs/build-step#root-directory"

Now a empty folder named "frontend" will be created in gh-pages branch everytime when "backend test coverage" hook will be called. Then in vercel setting>git added below custom "Ignored Build Step". 


`if [ "$VERCEL_GIT_COMMIT_REF" != "gh-pages" ]; then exit 1; else exit 0; fi`