### PR TITLE
96 add auth store to easily manage authorization in frontend

### DIFF
--- a/backend/constants/index.ts
+++ b/backend/constants/index.ts
@@ -18,18 +18,26 @@ export const BASE_URL = `${HOST}:${PORT}/`;
 export const NODE_ENV = process.env.NODE_ENV || "local";
 
 /** this api urls can be access without need of user email verified */
-export const ALLOWED_URLS_WO_MAIL_VERIFIED = [
+export const ALLOWED_PATHS_WITHOUT_MAIL_VERIFIED = [
   {
     path: "/user/resendEmailVerification/",
+    method: ["POST"],
+  },
+  {
+    path: "/auth/getAccessToken",
     method: ["POST"],
   },
 ];
 
 /** this api urls can be access without need of user logged in */
-export const ALLOWED_API_REQ_WO_USER_LOGGED_IN = [
+export const ALLOWED_PATHS_WITHOUT_USER_LOGGED_IN = [
   {
     path: "/organizations/invitations/accept",
     method: ["GET"],
+  },
+  {
+    path: "/auth/getAccessToken",
+    method: ["POST"],
   },
 ];
 
@@ -49,3 +57,10 @@ export const DEFAULT_ROLES = [
     isDefaultRole: true,
   },
 ] as Omit<Role, "_id">[];
+
+/**
+ * Some error messages
+ */
+
+export const INVALID_TOKEN_MSG = "Invalid token";
+export const EMAIL_NOT_VERIFIED_MSG = "Email not verified";

--- a/backend/utils/token.test.ts
+++ b/backend/utils/token.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/utils";
 import { isValidObjectId } from "mongoose";
 import tokenModel from "@app/models/token";
+import { INVALID_TOKEN_MSG } from "@app/constants";
 const {
   Types: { ObjectId },
 } = require("mongoose");
@@ -130,7 +131,7 @@ describe("useToken tests", function () {
     try {
       await useToken(inValidJwtToken, false, false);
     } catch (error) {
-      expect(error).toEqual(new Error("invalid token"));
+      expect(error).toEqual(new Error(INVALID_TOKEN_MSG));
     }
   });
 
@@ -158,7 +159,7 @@ describe("useToken tests", function () {
     try {
       await useToken(notExistDBValidJwtToken, false, true);
     } catch (error) {
-      expect(error).toEqual(new Error("Token does not exist"));
+      expect(error).toEqual(new Error(INVALID_TOKEN_MSG));
     }
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2",
-    "style-loader": "^3.3.3"
+    "style-loader": "^3.3.3",
+    "zustand": "^4.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.8",

--- a/frontend/src/bootstrap/renderReactApp.tsx
+++ b/frontend/src/bootstrap/renderReactApp.tsx
@@ -8,9 +8,5 @@ import RenderMainApp from "./renderMain";
 export function renderReactApp() {
   const container = document.getElementById("root");
   const root = createRoot(container);
-  root.render(
-    <React.StrictMode>
-      <RenderMainApp />
-    </React.StrictMode>
-  );
+  root.render(<RenderMainApp />);
 }

--- a/frontend/src/components/form.tsx
+++ b/frontend/src/components/form.tsx
@@ -100,8 +100,8 @@ function Form(props: Props) {
           return;
         }
       }
-
       // if it is unexpected error or internal server error
+      console.error(error);
       setFormError("Something went wrong.");
     } finally {
       setState((cs) => ({ ...cs, isFormBusy: false }));

--- a/frontend/src/hooks/useAPIClient.tsx
+++ b/frontend/src/hooks/useAPIClient.tsx
@@ -1,14 +1,21 @@
+import { useAuthStore } from "@app/stores/authStore";
 import { apiClient } from "@app/utils/apiClient";
-import { AxiosRequestConfig } from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import { useRef } from "react";
 
 /**
- * The useAPIClient function returns an object with a client function that makes API requests and a
- * cancelRequest function that cancels the ongoing request.
- * @returns The `useAPIClient` function returns an object with two properties: `client` and
- * `cancelRequest`.
+ * Use this hook to make any api request to backend, this hook give two main feature which we want to use:
+ * 1. It give you a function callback which can be used to cancel a ongoing request created by current client instance
+ * 2. It will handle some know cause where api request could be failed, E.g. email not verified, token expired.
+ *
+ *
+ * @returns {Object} An object with the following properties:
+ *   - `client`: A function to make API requests.
+ *   - `cancelRequest`: A function to cancel the ongoing request.
  */
 const useAPIClient = () => {
+  const { refreshToken, logout } = useAuthStore();
+
   /**
    * FAQ: Why are we using 'useRef(new AbortController());'
    *
@@ -35,11 +42,60 @@ const useAPIClient = () => {
   const clientCallback = async <ResponseType,>(
     endpoint: string,
     axiosConfig: AxiosRequestConfig
-  ) =>
-    apiClient<ResponseType>(endpoint, {
-      ...axiosConfig,
-      signal: controller.current.signal,
-    });
+  ): Promise<ResponseType> => {
+    try {
+      return await apiClient<ResponseType>(endpoint, {
+        ...axiosConfig,
+        signal: controller.current.signal,
+      });
+    } catch (error) {
+      /**
+       * we already know axios will throw error here, if it is not axios error probably it is something we don't know how to handle,
+       * But if this is axios error, There could be some known causes when a api request will failed
+       */
+      if (axios.isAxiosError(error)) {
+        const statusCode = error.response.status;
+        const errorMessage = error.response.data.nonFieldError;
+
+        /**
+         * # Case 1. user token is expired or invalid
+         *    In this case we will try to get new access token using refresh token
+         */
+        if (statusCode === 401 && errorMessage === "Invalid token") {
+          // fetch new access token
+          const newAccessToken = await refreshToken();
+
+          // once new access token successfully fetched, we will retry previous api call
+          if (newAccessToken) {
+            const previousAxiosConfig = error.config;
+            previousAxiosConfig.headers[
+              "Authorization"
+            ] = `Bearer ${newAccessToken}`;
+
+            // we want to use clientCallback recursively here, so that case 2 (email not verified) can be checked on retry previous api call
+            return await clientCallback(endpoint, previousAxiosConfig);
+          }
+
+          // if we are unable to refresh access token, we will logout user and redirect to login page
+          logout();
+          return;
+        }
+
+        /**
+         * #2 Case: user has not verified his email
+         * In this case we don't want to logout user but redirect him to email not verified screen
+         */
+        if (statusCode === 403) {
+          // redirect user to email not verified screen
+          window.location.href = "/verify-email";
+          return;
+        }
+      }
+
+      // else just throw original error
+      throw error;
+    }
+  };
 
   /**
    * The cancelRequest function cancels the ongoing API request by aborting the current AbortController

--- a/frontend/src/routes.tsx
+++ b/frontend/src/routes.tsx
@@ -10,7 +10,7 @@ const routes = (
     <Routes>
       <Route>
         {/* Unauthorized Routes - Don't require user login */}
-        <Route Component={AuthLayout}>
+        <Route path="auth" Component={AuthLayout}>
           <Route path="register" Component={Register} />
           <Route path="login" Component={Login} />
         </Route>

--- a/frontend/src/stores/authStore.tsx
+++ b/frontend/src/stores/authStore.tsx
@@ -1,0 +1,69 @@
+import { User } from "@app/types/user";
+import { apiClient } from "@app/utils/apiClient";
+import {
+  getAccessToken,
+  getRefreshToken,
+  getUser,
+  resetLocalStorage,
+  setAccessToken,
+  setRefreshToken,
+  setUser,
+} from "@app/utils/storage";
+import { create } from "zustand";
+
+interface AuthState {
+  /** Is user logged in */
+  isAuthenticated: boolean;
+  /** Logged in user details */
+  user: User | null;
+  /** Initialize auth store with provided user tokens */
+  init: (accessToken: string, refreshToken: string) => Promise<void>;
+  /** Refresh access token using this function */
+  refreshToken: () => Promise<string>;
+  /** Logout current user and redirect to login page */
+  logout: () => void;
+}
+
+/**
+ * User this store manage user authentication
+ */
+export const useAuthStore = create<AuthState>((set, get) => ({
+  isAuthenticated: !!getAccessToken(),
+  user: getUser(),
+
+  init: async (accessToken, refreshToken) => {
+    resetLocalStorage();
+
+    // first we will save tokens in local storage
+    setAccessToken(accessToken);
+    setRefreshToken(refreshToken);
+
+    // now we will try to fetch user details
+    const user = await apiClient<User>("user/me/", {});
+    setUser(user);
+    set((cs) => ({
+      ...cs,
+      isAuthenticated: true,
+      user: user,
+    }));
+  },
+
+  refreshToken: async () => {
+    const { accessToken } = await apiClient<{ accessToken: string }>(
+      "auth/getAccessToken",
+      {
+        method: "POST",
+        data: {
+          refreshToken: getRefreshToken(),
+        },
+      }
+    );
+    setAccessToken(accessToken);
+    return accessToken;
+  },
+
+  logout: () => {
+    resetLocalStorage();
+    window.location.href = "/auth/login";
+  },
+}));

--- a/frontend/src/utils/apiClient/client.tsx
+++ b/frontend/src/utils/apiClient/client.tsx
@@ -1,14 +1,7 @@
 import axios from "axios";
-import { onRequestFulfilled, onResponseRejected } from "./interceptors";
+import { onRequestFulfilled } from "./interceptors";
 
-const baseURL = ` ${process.env.REACT_APP_BACKEND_URL}/api/`;
-
-const client = axios.create({
-  baseURL,
-  headers: { Accept: "application/json", "Content-Type": "application/json" },
-});
-
+const client = axios.create();
 client.interceptors.request.use(onRequestFulfilled);
-client.interceptors.response.use((response) => response, onResponseRejected);
 
 export default client;

--- a/frontend/src/utils/apiClient/headers.tsx
+++ b/frontend/src/utils/apiClient/headers.tsx
@@ -2,18 +2,20 @@ import { AxiosHeaders } from "axios";
 import { getAccessToken } from "../storage";
 
 /**
- * The function generates headers for an Axios request with an access token.
- * @returns an instance of the AxiosHeaders class with the specified headers and the authorization
- * header set with the access token.
+ * The function generates headers for an Axios request with authorization and CORS settings.
+ * @returns an instance of the AxiosHeaders class with the specified headers.
  */
 export function generateHeaders(): AxiosHeaders {
+  const accessToken = getAccessToken();
+
   const headers = new AxiosHeaders({
     Accept: "application/json; charset=utf-8",
     ["Content-Type"]: "application/json",
+    ["Access-Control-Allow-Origin"]: "*",
+    ["Access-Control-Allow-Headers"]: "*",
+    ["Access-Control-Allow-Methods"]: "*",
+    authorization: `Bearer ${accessToken}`,
   });
-
-  const accessToken = getAccessToken();
-  headers.set("authorization", `Bearer ${accessToken}`);
 
   return headers;
 }

--- a/frontend/src/utils/apiClient/interceptors.tsx
+++ b/frontend/src/utils/apiClient/interceptors.tsx
@@ -1,44 +1,11 @@
-import { InternalAxiosRequestConfig, isAxiosError } from "axios";
+import { InternalAxiosRequestConfig } from "axios";
 import { generateHeaders } from "./headers";
 
+const baseURL = ` ${process.env.REACT_APP_BACKEND_URL}/api/`;
+
 export function onRequestFulfilled(config: InternalAxiosRequestConfig) {
+  config.baseURL = baseURL;
   config.headers = generateHeaders();
 
   return config;
-}
-
-export function onResponseRejected(error: unknown) {
-  /**
-   * we already know axios will throw error here, if it is not axios error probably it is something we don't know how to handle,
-   * But if this is axios error, There could be some known causes when a api request will failed
-   */
-  if (isAxiosError(error) && error.response) {
-    const statusCode = error.response.status;
-    const responseBody = error.response.data;
-
-    /**
-     * #1 Case: user token is expired or invalid
-     * In this case we will logout user manually and redirect him to login screen
-     */
-    if (statusCode === 401 && window.location.pathname !== "/login") {
-      // logout user and redirect to login page
-      window.location.href = "/login";
-      return;
-    }
-
-    /**
-     * #2 Case: user has not verified his email
-     * In this case we don't want to logout user but redirect him to email not verified screen
-     */
-    if (
-      statusCode === 403 &&
-      responseBody.nonFieldError === "Email not verified"
-    ) {
-      // redirect user to email not verified screen
-      window.location.href = "/verify-email";
-      return;
-    }
-  }
-
-  return Promise.reject(error);
 }

--- a/frontend/src/utils/storage/index.tsx
+++ b/frontend/src/utils/storage/index.tsx
@@ -4,6 +4,7 @@ import { removeUser } from "./user";
 
 export * from "./accessToken";
 export * from "./refreshToken";
+export * from "./user";
 
 export const STORAGE_SUFFIX = "CRM-WEBAPP";
 

--- a/frontend/src/views/home.tsx
+++ b/frontend/src/views/home.tsx
@@ -1,16 +1,13 @@
-import React from "react";
 import "../styles/App.css";
 import { Button, Title } from "@mantine/core";
-import { getUser } from "@app/utils/storage/user";
-import { resetLocalStorage } from "@app/utils/storage";
+import { useAuthStore } from "@app/stores/authStore";
 
 function Home() {
-  const user = getUser();
-  const handleLogout = () => resetLocalStorage();
+  const { user, logout } = useAuthStore();
   return (
     <div>
       <Title>Welcome {user.name}</Title>
-      <Button onClick={handleLogout}>Logout</Button>
+      <Button onClick={logout}>Logout</Button>
     </div>
   );
 }

--- a/frontend/src/views/index.tsx
+++ b/frontend/src/views/index.tsx
@@ -1,22 +1,12 @@
-import { getAccessToken } from "@app/utils/storage";
-import { getUser } from "@app/utils/storage/user";
+import { useAuthStore } from "@app/stores/authStore";
 import { Box, Flex, Loader, Text } from "@mantine/core";
 import { Outlet } from "react-router-dom";
 
-type State = {
-  isAuthenticated: boolean;
-};
-
 function App() {
-  const user = getUser();
-  const isAuthenticated = !!user;
+  const { isAuthenticated, user, logout } = useAuthStore();
 
-  const redirectToLogin = () => {
-    window.location.href = "/login";
-  };
-
-  if (!isAuthenticated) {
-    redirectToLogin();
+  if (!isAuthenticated || !user) {
+    logout();
     return (
       <Flex w="100%" h="100vh" align="center" justify="center" gap="md">
         <Text fw="lighter" size="xl">

--- a/frontend/src/views/login.tsx
+++ b/frontend/src/views/login.tsx
@@ -1,13 +1,7 @@
 import { Button } from "@app/components/button";
 import Form, { SetFormError } from "@app/components/form";
-import { User } from "@app/types/user";
-import { apiClient } from "@app/utils/apiClient";
-import {
-  resetLocalStorage,
-  setAccessToken,
-  setRefreshToken,
-} from "@app/utils/storage";
-import { setUser } from "@app/utils/storage/user";
+import { useAuthStore } from "@app/stores/authStore";
+import { resetLocalStorage } from "@app/utils/storage";
 import {
   Container,
   Divider,
@@ -19,6 +13,8 @@ import {
 import { useForm } from "@mantine/form";
 
 function Login() {
+  const authStore = useAuthStore();
+
   const form = useForm({
     initialValues: {
       email: "",
@@ -45,20 +41,9 @@ function Login() {
       setFormError("Invalid token");
       return;
     }
-    // once login credentials validated successfully, first we will save access token and refresh token in client local storage
-    setAccessToken(accessToken);
-    setRefreshToken(refreshToken);
-    fetchUserInfo();
-  };
-
-  const fetchUserInfo = async () => {
-    try {
-      const userInfo = await apiClient<User>("user/me/", {});
-      setUser(userInfo);
-      window.location.href = "/";
-    } catch (error) {
-      console.log("unable to fetch user");
-    }
+    // once login credentials validated successfully, we will initialize auth store
+    await authStore.init(accessToken, refreshToken);
+    window.location.href = "/";
   };
 
   return (
@@ -84,7 +69,7 @@ function Login() {
         </Form>
         <Divider label="OR" labelPosition="center" />
         <Group grow>
-          <Button variant="light" to="/register">
+          <Button variant="light" to="/auth/register">
             Register
           </Button>
         </Group>

--- a/frontend/src/views/register.tsx
+++ b/frontend/src/views/register.tsx
@@ -61,7 +61,7 @@ function Register() {
         </Form>
         <Divider label="OR" labelPosition="center" />
         <Group grow>
-          <Button variant="light" to="/login">
+          <Button variant="light" to="/auth/login">
             Login
           </Button>
         </Group>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -21,7 +21,7 @@
       ],
       "@shared/*": [
         "../shared/*"
-      ]
+      ],
     }
   },
   "exclude": [

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3249,6 +3249,7 @@ __metadata:
     webpack: "npm:^5.83.1"
     webpack-cli: "npm:^5.1.1"
     webpack-dev-server: "npm:^4.15.0"
+    zustand: "npm:^4.4.1"
   languageName: unknown
   linkType: soft
 
@@ -6945,6 +6946,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"use-sync-external-store@npm:1.2.0":
+  version: 1.2.0
+  resolution: "use-sync-external-store@npm:1.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: bed3d1f68ca3dd33647035dbeb9d3a5ece12fced0245cb0fa831426192e52e4948b0fc6e9187d9d4dce9f58269af605f8feeeda100d2928f8b865f9cd9cc4a4a
+  languageName: node
+  linkType: hard
+
 "util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
@@ -7257,5 +7267,25 @@ __metadata:
   version: 3.1.1
   resolution: "yn@npm:3.1.1"
   checksum: 890a9ce10f1f6691316f521444dcdc2d012dbfba423ec2252444dab5888def4ee48751304e51302c6d14197a1e9407256153a357c955bff1d659df592cfda456
+  languageName: node
+  linkType: hard
+
+"zustand@npm:^4.4.1":
+  version: 4.4.1
+  resolution: "zustand@npm:4.4.1"
+  dependencies:
+    use-sync-external-store: "npm:1.2.0"
+  peerDependencies:
+    "@types/react": ">=16.8"
+    immer: ">=9.0"
+    react: ">=16.8"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    immer:
+      optional: true
+    react:
+      optional: true
+  checksum: 8384ce68251736b66f3b9e2cc40cffcfb4346618100a5f8cc62e639b50b87b6b74b36fd8a0ce0bcfae40c1d56de9f21bc99966982341d45d0b2663a5c3202dec
   languageName: node
   linkType: hard


### PR DESCRIPTION
- [frontend] Now access token can be refresh automatically once expired, and Refactored API client and hook
- [frontend] Added auth store and imepleted it in the app
- [frontend] Fixed app was rerender two times
- [backend] Added refresh token path into allowed paths list which can be access without login and email verified, and Added default refresh token expiry for 7 days, Refactor Auth middleware
- [frontend] Added zustand for state management